### PR TITLE
Update comprehension.sld

### DIFF
--- a/spheres/algorithm/comprehension.sld
+++ b/spheres/algorithm/comprehension.sld
@@ -30,7 +30,9 @@
           :let
           :parallel
           :while
-          :until)
+          :until
+          
+          :-dispatch)
 
   ;;! (do-ec q ... cmd)
   ;;   handles nested, if/not/and/or, begin, :let, and calls generator 


### PR DESCRIPTION
added :-dispatch to export list, so short form (list-ec(: x 5) x) would work again.
