### PR TITLE
fixed missing dependency for string-null? in sxml-parser

### DIFF
--- a/spheres/markup/sxml-parser.sld
+++ b/spheres/markup/sxml-parser.sld
@@ -9,5 +9,7 @@
           html-entity-unicode-numbers
           html-entity-unicode-chars)
   (import (spheres/core base))
+  (import (spheres/string string))
+
 
   (include "sxml-parser.scm"))

--- a/spheres/markup/sxml-tools.sld
+++ b/spheres/markup/sxml-tools.sld
@@ -68,7 +68,14 @@
           sxml:attr->html
           sxml:string->html
           sxml:non-terminated-html-tag?
-          sxml:sxml->html)
+          sxml:sxml->html
+	  sxml:node?
+	  ntype??
+	  select-kids
+	  as-nodeset
+	  nodeset?
+	  map-union
+	  sxml:child)
 
   (import (spheres/core base)
           (spheres/string string))

--- a/spheres/object/prototype.sld
+++ b/spheres/object/prototype.sld
@@ -11,7 +11,9 @@
           prototype:deep-clone-method
           prototype:make-setter-getter
           make-prototype-object
+	  prototype-object?
           prototype:make-dispatch-table
+	  prototype:find-method
           string<<
           $
           <<


### PR DESCRIPTION
Problem:

```
> (load (spheres/markup sxml-parser))
> (xml-string->sxml "<html><head><title>CIAO</title></head><body background=\"white\"><p>MONDO</p></body></html>")
*** ERROR IN #<procedure #3> -- Unbound variable: spheres/core#base#string-null?
```

after fix:

```
> (load (spheres/markup sxml-parser))                                                                             
> (xml-string->sxml "<html><head><title>CIAO</title></head><body background=\"white\"><p>MONDO</p></body></html>")
(*TOP* (html (head (title "CIAO")) (body (@ (background "white")) (p "MONDO"))))
```
