### PR TITLE
Changed default value for make-final in string-unfold, as per specification.

### DIFF
--- a/spheres/string/string.scm
+++ b/spheres/string/string.scm
@@ -197,7 +197,7 @@
 ;;; and longer ones. When done, we allocate an answer string and copy the
 ;;; chars over from the chunk buffers.
 
-(define* (string-unfold p f g seed (base "") (make-final (lambda (x) x)))
+(define* (string-unfold p f g seed (base "") (make-final (lambda (x) "")))
   (let lp ((chunks '())             ; Previously filled chunks
            (nchars 0)               ; Number of chars in CHUNKS
            (chunk (make-string 40)) ; Current chunk into which we write


### PR DESCRIPTION
SRFI-13 says the default value for make-final should be (lambda (x) "") , not (lambda (x) x).
Problem also present in klio library.

This one liner now works:

(string-unfold null? car cdr '(#\1 #\2 #\3 #\4))
