### PR TITLE
fixed unfold in list.scm

### DIFF
--- a/spheres/algorithm/list.scm
+++ b/spheres/algorithm/list.scm
@@ -637,9 +637,9 @@
   (check-arg procedure? p unfold)
   (check-arg procedure? f unfold)
   (check-arg procedure? g unfold)
-  (if tail-gen
+  (if (pair? tail-gen)
       (let recur ((seed seed))
-        (if (p seed) (tail-gen seed)
+        (if (p seed) ((car tail-gen) seed)
             (cons (f seed) (recur (g seed)))))
       (let recur ((seed seed))
         (if (p seed) '()


### PR DESCRIPTION
Hello!

Minimal patch to unfold, still missing additional checks present in the reference.

These one-liners now work:

```
(unfold null-list? car cdr '(1 2 3 4 5) )                            
=> (1 2 3 4 5)

(unfold null-list? car cdr '(1 2 3 4 5) (lambda (x) 'this-is-the-end))  
=> (1 2 3 4 5 . this-is-the-end)
```
